### PR TITLE
Issue 4. Prevent JitPreloader::Preloader from being dumped 

### DIFF
--- a/lib/jit_preloader/preloader.rb
+++ b/lib/jit_preloader/preloader.rb
@@ -19,5 +19,19 @@ module JitPreloader
       preload records_with_association, association
     end
 
+    # We do not want the jit_preloader to be dumpable
+    # If you dump a ActiveRecord::Base object that has a jit_preloader instance variable
+    # you will also end up dumping all of the records the preloader has reference to. 
+    # Imagine getting N objects from a query and dumping each one of those into a cache
+    # each object would dump N+1 objects which means you'll end up storing O(N^2) memory. Thats no good.
+    # So instead, we will just nullify the jit_preloader on load
+    def _dump(level)
+      ""
+    end
+
+    def self._load(args)
+      nil
+    end
+
   end
 end

--- a/spec/lib/jit_preloader/preloader_spec.rb
+++ b/spec/lib/jit_preloader/preloader_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe JitPreloader::Preloader do
     ->(event, data){ source_map[data[:source]] << data[:association] }
   end
 
+  context "when we marshal dump the active record object" do
+    it "nullifes the jit_preloader reference" do
+      contacts = Contact.jit_preload.to_a
+      reloaded_contacts = contacts.collect{|r| Marshal.load(Marshal.dump(r)) }
+      contacts.each do |c|
+        expect(c.jit_preloader).to_not be_nil
+      end
+      reloaded_contacts.each do |c|
+        expect(c.jit_preloader).to be_nil
+      end
+    end
+  end
+
   context "when the preloader is globally enabled" do
     around do |example|
       JitPreloader.globally_enabled = true


### PR DESCRIPTION
in any meaningful form to reduce memory footprints when caching objects.

Now when you marshal a object with JIT preloader enabled, the marshal dump is a constant size larger than an object without it

```ruby
puts Marshal.dump(Contact.first).inspect
# => "\x04\bo:\fContact\x10:\x10@attributeso:\x1FActiveRecord::AttributeSet\x06;\x06o:$ActiveRecord::LazyAttributeHash\n:\v@types}\aI\"\aid\x06:\x06ETo: ActiveRecord::Type::Integer\t:\x0F@precision0:\v@scale0:\v@limit0:\v@rangeo:\nRange\b:\texclT:\nbeginl-\a\x00\x00\x00\x80:\bendl+\a\x00\x00\x00\x80I\"\tname\x06;\nTo:\x1FActiveRecord::Type::String\b;\f0;\r0;\x0Ei\x01\xFFo:\x1EActiveRecord::Type::Value\b;\f0;\r0;\x0E0:\f@values{\aI\"\aid\x06;\nTi\x06I\"\tname\x06;\nTI\"\x13Only Addresses\x06;\nT:\x16@additional_types{\x00:\x12@materializedF:\x13@delegate_hash{\x00:\x17@aggregation_cache{\x00:\x17@association_cache{\x00:\x0E@readonlyF:\x0F@destroyedF:\x1C@marked_for_destructionF:\x1E@destroyed_by_association0:\x10@new_recordF:\t@txn0:\x1E@_start_transaction_state{\x00:\x17@transaction_state0"

puts Marshal.dump(Contact.jit_preload.to_a.first).inspect
# => "\x04\bo:\fContact\x12:\x10@attributeso:\x1FActiveRecord::AttributeSet\x06;\x06o:$ActiveRecord::LazyAttributeHash\n:\v@types}\aI\"\aid\x06:\x06ETo: ActiveRecord::Type::Integer\t:\x0F@precision0:\v@scale0:\v@limit0:\v@rangeo:\nRange\b:\texclT:\nbeginl-\a\x00\x00\x00\x80:\bendl+\a\x00\x00\x00\x80I\"\tname\x06;\nTo:\x1FActiveRecord::Type::String\b;\f0;\r0;\x0Ei\x01\xFFo:\x1EActiveRecord::Type::Value\b;\f0;\r0;\x0E0:\f@values{\aI\"\aid\x06;\nTi\x06I\"\tname\x06;\nTI\"\x13Only Addresses\x06;\nT:\x16@additional_types{\x00:\x12@materializedF:\x13@delegate_hash{\x00:\x17@aggregation_cache{\x00:\x17@association_cache{\x00:\x0E@readonlyF:\x0F@destroyedF:\x1C@marked_for_destructionF:\x1E@destroyed_by_association0:\x10@new_recordF:\t@txn0:\x1E@_start_transaction_state{\x00:\x17@transaction_state0:\x1D@jit_n_plus_one_trackingT:\x13@jit_preloaderIu:\x1CJitPreloader::Preloader\x00\x06;\nT"
```